### PR TITLE
[feature] Add pod disruption budget

### DIFF
--- a/idsvr/templates/pdb.yaml
+++ b/idsvr/templates/pdb.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "curity.fullname" . }}-runtime
+  labels:
+    {{- include "curity.labels" . | nindent 4 }}
+    role: {{ include "curity.fullname" . }}-runtime
+spec:
+  {{- if .Values.curity.runtime.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.curity.runtime.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- if .Values.curity.runtime.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.curity.runtime.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "curity.labels" . | nindent 6 }}
+      role: {{ include "curity.fullname" . }}-runtime
+{{- end }}

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -81,6 +81,9 @@ curity:
       annotations: {}
     serviceAccount:
       name:
+    podDisruptionBudget:
+      minAvailable: 1
+      # maxUnavailable: 1
     deployment:
       port: 8443
     livenessProbe:


### PR DESCRIPTION
## Description

Proposition to add pod disruption budget to increase the availability especially in fast moving environments.

## Reference

https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets